### PR TITLE
Implement various score functions (#217)

### DIFF
--- a/src/main/org/deidentifier/arx/algorithm/DataDependentEDDPAlgorithm.java
+++ b/src/main/org/deidentifier/arx/algorithm/DataDependentEDDPAlgorithm.java
@@ -50,8 +50,11 @@ public class DataDependentEDDPAlgorithm extends AbstractAlgorithm {
     /** Number of steps to be performed */
     private final int                        steps;
 
-    /** The expopnential mechanism */
-    private final ExponentialMechanism<Long> exponentialMechanism;
+    /** Privacy budget to use for each execution of the exponential mechanism */
+    private final double                     epsilonPerStep;
+
+    /** True iff this algorithm should be executed in a deterministic manner */
+    private final boolean                    deterministic;
 
     /**
      * Creates a new instance
@@ -82,12 +85,11 @@ public class DataDependentEDDPAlgorithm extends AbstractAlgorithm {
         this.propertyChecked = space.getPropertyChecked();
         this.solutionSpace.setAnonymityPropertyPredictable(false);
         this.steps = steps;
+        this.deterministic = deterministic;
 
-        double epsilonPerStep;
         IntervalArithmeticDouble arithmetic = new IntervalArithmeticDouble();
         try {
-            epsilonPerStep = arithmetic.div(arithmetic.createInterval(epsilonSearch), arithmetic.createInterval(steps)).lower;
-            exponentialMechanism = new ExponentialMechanism<Long>(epsilonPerStep, deterministic);
+            this.epsilonPerStep = arithmetic.div(arithmetic.createInterval(epsilonSearch), arithmetic.createInterval(steps)).lower;
         } catch (IntervalArithmeticException e) {
             throw new RuntimeException(e);
         }
@@ -95,6 +97,15 @@ public class DataDependentEDDPAlgorithm extends AbstractAlgorithm {
     
     @Override
     public boolean traverse() {
+        
+        // Create a new local ExponentialMechanism instance in order to reduce memory consumption caused
+        // by internal caches used by this class
+        ExponentialMechanism<Long> exponentialMechanism;
+        try {
+            exponentialMechanism = new ExponentialMechanism<Long>(epsilonPerStep, deterministic);
+        } catch (IntervalArithmeticException e) {
+            throw new RuntimeException(e);
+        }
         
         // Set the top-transformation to be the initial pivot element
         Transformation pivot = solutionSpace.getTop();
@@ -128,7 +139,7 @@ public class DataDependentEDDPAlgorithm extends AbstractAlgorithm {
             transformationIDToScore.remove(pivot.getIdentifier());
             
             // Select the next pivot element from the set of candidates using the exponential mechanism
-            long id = executeExponentialMechanism(transformationIDToScore);
+            long id = executeExponentialMechanism(transformationIDToScore, exponentialMechanism);
             pivot = solutionSpace.getTransformation(id);
             score = transformationIDToScore.get(id);
             
@@ -159,9 +170,10 @@ public class DataDependentEDDPAlgorithm extends AbstractAlgorithm {
     /**
      * Executes the exponential mechanism
      * @param transformationIDToScore
+     * @param exponentialMechanism 
      * @return
      */
-    private long executeExponentialMechanism(Map<Long, ILScore> transformationIDToScore) {
+    private long executeExponentialMechanism(Map<Long, ILScore> transformationIDToScore, ExponentialMechanism<Long> exponentialMechanism) {
         
         // Convert the map into arrays of the types required by the exponential mechanism
 

--- a/src/main/org/deidentifier/arx/metric/v2/AbstractMetricMultiDimensional.java
+++ b/src/main/org/deidentifier/arx/metric/v2/AbstractMetricMultiDimensional.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 
 import org.deidentifier.arx.ARXConfiguration;
 import org.deidentifier.arx.DataDefinition;
+import org.deidentifier.arx.criteria.EDDifferentialPrivacy;
 import org.deidentifier.arx.framework.check.distribution.DistributionAggregateFunction;
 import org.deidentifier.arx.framework.data.Data;
 import org.deidentifier.arx.framework.data.DataAggregationInformation;
@@ -38,31 +39,34 @@ import org.deidentifier.arx.metric.Metric;
 public abstract class AbstractMetricMultiDimensional extends Metric<AbstractILMultiDimensional> {
 
     /** SVUID. */
-    private static final long               serialVersionUID = 3909752748519119689L;
+    private static final long          serialVersionUID = 3909752748519119689L;
 
     /** The weights. */
-    private double[]                        weights;
+    private double[]                   weights;
 
     /** Number of dimensions. */
-    private int                             dimensions;
+    private int                        dimensions;
 
     /** Number of dimensions with generalization */
-    private int                             dimensionsGeneralized;
+    private int                        dimensionsGeneralized;
 
     /** Number of dimensions with aggregation */
-    private int                             dimensionsAggregated;
+    private int                        dimensionsAggregated;
 
     /** Min. */
-    private double[]                        min;
+    private double[]                   min;
 
     /** Max. */
-    private double[]                        max;
+    private double[]                   max;
 
     /** The aggregate function. */
-    private AggregateFunction               function;
+    private AggregateFunction          function;
 
     /** The microaggregation functions. */
-    private DataAggregationInformation            aggregation;
+    private DataAggregationInformation aggregation;
+
+    /** Minimal size of equivalence classes enforced by the differential privacy model */
+    protected int                      k;
 
     /**
      * Creates a new instance.
@@ -282,6 +286,12 @@ public abstract class AbstractMetricMultiDimensional extends Metric<AbstractILMu
         Arrays.fill(min, 0d);
         this.max = new double[this.dimensions];
         Arrays.fill(max, Double.MAX_VALUE);
+        
+        if (config.isPrivacyModelSpecified(EDDifferentialPrivacy.class)) {
+            // Store minimal size of equivalence classes
+            EDDifferentialPrivacy dpCriterion = config.getPrivacyModel(EDDifferentialPrivacy.class);
+            this.k = dpCriterion.getMinimalClassSize();
+        }
     }
 
     /**

--- a/src/main/org/deidentifier/arx/metric/v2/AbstractMetricMultiDimensionalPotentiallyPrecomputed.java
+++ b/src/main/org/deidentifier/arx/metric/v2/AbstractMetricMultiDimensionalPotentiallyPrecomputed.java
@@ -128,6 +128,13 @@ public abstract class AbstractMetricMultiDimensionalPotentiallyPrecomputed exten
     public double getGeneralizationSuppressionFactor() {
         return defaultMetric.getGeneralizationSuppressionFactor();
     }
+    
+    @Override
+    public ILScore getScore(final Transformation node, final HashGroupify groupify) {
+        return precomputed ?
+               precomputedMetric.getScore(node, groupify) :
+               defaultMetric.getScore(node, groupify);
+    }
 
     @Override
     public double getSuppressionFactor() {
@@ -143,6 +150,11 @@ public abstract class AbstractMetricMultiDimensionalPotentiallyPrecomputed exten
     @Override
     public boolean isPrecomputed() {
         return this.precomputed;
+    }
+    
+    @Override
+    public boolean isScoreFunctionSupported() {
+        return isPrecomputed() ? precomputedMetric.isScoreFunctionSupported() : defaultMetric.isScoreFunctionSupported();
     }
 
     /**

--- a/src/main/org/deidentifier/arx/metric/v2/MetricMDNMLoss.java
+++ b/src/main/org/deidentifier/arx/metric/v2/MetricMDNMLoss.java
@@ -17,11 +17,15 @@
 
 package org.deidentifier.arx.metric.v2;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
+import org.apache.commons.math3.fraction.BigFraction;
 import org.deidentifier.arx.ARXConfiguration;
 import org.deidentifier.arx.DataDefinition;
 import org.deidentifier.arx.certificate.elements.ElementData;
+import org.deidentifier.arx.criteria.EDDifferentialPrivacy;
 import org.deidentifier.arx.framework.check.distribution.DistributionAggregateFunction;
 import org.deidentifier.arx.framework.check.groupify.HashGroupify;
 import org.deidentifier.arx.framework.check.groupify.HashGroupifyEntry;
@@ -31,30 +35,36 @@ import org.deidentifier.arx.framework.data.GeneralizationHierarchy;
 import org.deidentifier.arx.framework.lattice.Transformation;
 import org.deidentifier.arx.metric.MetricConfiguration;
 
+import com.carrotsearch.hppc.ObjectIntOpenHashMap;
+
 /**
  * This class implements a variant of the Loss metric.
  *
  * @author Fabian Prasser
+ * @author Raffael Bild
  */
 public class MetricMDNMLoss extends AbstractMetricMultiDimensional {
 
     /** SUID. */
-    private static final long serialVersionUID = -573670902335136600L;
+    private static final long     serialVersionUID = -573670902335136600L;
 
     /** Total number of tuples, depends on existence of research subset. */
-    private double            tuples;
+    private double                tuples;
 
     /** Domain shares for each dimension. */
-    private DomainShare[]     shares;
+    private DomainShare[]         shares;
+
+    /** Reliable domain shares for each dimension. */
+    private DomainShareReliable[] sharesReliable;
 
     /** We must override this for backward compatibility. Remove, when re-implemented. */
-    private final double      gFactor;
-    
+    private final double          gFactor;
+
     /** We must override this for backward compatibility. Remove, when re-implemented. */
-    private final double      gsFactor;
-    
+    private final double          gsFactor;
+
     /** We must override this for backward compatibility. Remove, when re-implemented. */
-    private final double      sFactor;
+    private final double          sFactor;
     
     /**
      * Default constructor which treats all transformation methods equally.
@@ -121,6 +131,64 @@ public class MetricMDNMLoss extends AbstractMetricMultiDimensional {
     public String getName() {
         return "Loss";
     }
+
+    @Override
+    public ILScore getScore(final Transformation node, final HashGroupify groupify) {
+        // Prepare
+        int[] transformation = node.getGeneralization();
+        int dimensionsGeneralized = getDimensionsGeneralized();
+        List<ObjectIntOpenHashMap<BigFraction>> dimensionSharesToCount =
+                new ArrayList<ObjectIntOpenHashMap<BigFraction>>(dimensionsGeneralized);
+        for (int dimension=0; dimension<dimensionsGeneralized; dimension++){
+            dimensionSharesToCount.add(new ObjectIntOpenHashMap<BigFraction>());
+        }
+
+        // Calculate counts. During these computations, no overflows can occur
+        // since a dataset can not contain more than Integer.MAX_VALUE records.
+        HashGroupifyEntry m = groupify.getFirstEquivalenceClass();
+        int numOutliers = 0;
+        while (m != null) {
+            m.read();
+            for (int dimension=0; dimension<dimensionsGeneralized; dimension++){
+                if (m.count>0) {
+                    if (!m.isNotOutlier) {
+                        numOutliers += m.count;
+                    } else {
+                        int value = m.next();
+                        int level = transformation[dimension];
+                        BigFraction shareReliable = sharesReliable[dimension].getShare(value, level);
+                        ObjectIntOpenHashMap<BigFraction> sharesToCount = dimensionSharesToCount.get(dimension);
+                        sharesToCount.putOrAdd(shareReliable, m.count, m.count);
+                    }
+                }
+                numOutliers += m.pcount - m.count;
+            }
+            m = m.nextOrdered;
+        }
+        
+        // Calculate score
+        BigFraction score = new BigFraction(numOutliers);
+        for (int dimension=0; dimension<dimensionsGeneralized; dimension++){
+            
+            ObjectIntOpenHashMap<BigFraction> sharesToCount = dimensionSharesToCount.get(dimension);
+            final boolean[] states = sharesToCount.allocated;
+            final int[] counts = sharesToCount.values;
+            final Object[] sharesReliable = sharesToCount.keys;
+            
+            for (int i=0; i<states.length; i++) {
+                if (states[i]) {
+                    score = score.add(((BigFraction)(sharesReliable[i])).multiply(counts[i]));
+                }
+            }
+        }
+
+        // Divide by sensitivity and multiply with -1 so that higher values are better
+        score = score.multiply(new BigFraction(-1, dimensionsGeneralized));
+        if (k > 1) score = score.divide(new BigFraction(k - 1));
+
+        // Return
+        return new ILScore(score);
+    }
     
     @Override
     public double getSuppressionFactor() {
@@ -134,6 +202,11 @@ public class MetricMDNMLoss extends AbstractMetricMultiDimensional {
 
     @Override
     public boolean isGSFactorSupported() {
+        return true;
+    }
+
+    @Override
+    public boolean isScoreFunctionSupported() {
         return true;
     }
 
@@ -305,6 +378,11 @@ public class MetricMDNMLoss extends AbstractMetricMultiDimensional {
         
         // Save domain shares
         this.shares = manager.getDomainShares();
+
+        if (config.isPrivacyModelSpecified(EDDifferentialPrivacy.class)) {
+            // Save reliable domain shares
+            sharesReliable = manager.getDomainSharesReliable();
+        }
         
         // Min and max
         double[] min = new double[getDimensions()];

--- a/src/main/org/deidentifier/arx/metric/v2/MetricMDNMPrecision.java
+++ b/src/main/org/deidentifier/arx/metric/v2/MetricMDNMPrecision.java
@@ -19,6 +19,7 @@ package org.deidentifier.arx.metric.v2;
 
 import java.util.Arrays;
 
+import org.apache.commons.math3.fraction.BigFraction;
 import org.deidentifier.arx.ARXConfiguration;
 import org.deidentifier.arx.DataDefinition;
 import org.deidentifier.arx.certificate.elements.ElementData;
@@ -41,6 +42,7 @@ import org.deidentifier.arx.metric.MetricConfiguration;
  * 
  * @author Fabian Prasser
  * @author Florian Kohlmayer
+ * @author Raffael Bild
  */
 public class MetricMDNMPrecision extends AbstractMetricMultiDimensional {
 
@@ -117,6 +119,43 @@ public class MetricMDNMPrecision extends AbstractMetricMultiDimensional {
                                        this.getAggregateFunction()                  // aggregate function
                                        );
     }
+    
+    @Override
+    public ILScore getScore(final Transformation node, final HashGroupify groupify) {
+        // Prepare
+        int[] transformation = node.getGeneralization();
+        int dimensionsGeneralized = getDimensionsGeneralized();
+        
+        int suppressedTuples = 0;
+        int unsuppressedTuples = 0;
+        
+        // For each group
+        HashGroupifyEntry m = groupify.getFirstEquivalenceClass();
+        while (m != null) {
+            
+            // Calculate number of affected records
+            unsuppressedTuples += m.isNotOutlier ? m.count : 0;
+            suppressedTuples += m.isNotOutlier ? 0 : m.count;
+            suppressedTuples += m.pcount - m.count;
+
+            // Next group
+            m = m.nextOrdered;
+        }
+        
+        // Calculate score
+        BigFraction score = new BigFraction(0);
+        for (int i = 0; i<dimensionsGeneralized; i++) {
+            BigFraction value = heights[i] == 0 ? BigFraction.ZERO : new BigFraction(transformation[i]).divide(new BigFraction(heights[i]));
+            score = score.add(new BigFraction(unsuppressedTuples).multiply(value).add(new BigFraction(suppressedTuples)));
+        }
+        
+        // Divide by sensitivity and multiply with -1 so that higher values are better
+        score = score.multiply(BigFraction.MINUS_ONE.divide(new BigFraction(getDimensionsGeneralized())));
+        if (k > 1) score = score.divide(new BigFraction(k - 1));
+        
+        // Return score
+        return new ILScore(score);
+    }
 
     @Override
     public boolean isAbleToHandleMicroaggregation() {
@@ -125,6 +164,11 @@ public class MetricMDNMPrecision extends AbstractMetricMultiDimensional {
     
     @Override
     public boolean isGSFactorSupported() {
+        return true;
+    }
+    
+    @Override
+    public boolean isScoreFunctionSupported() {
         return true;
     }
 

--- a/src/main/org/deidentifier/arx/metric/v2/MetricMDNUEntropyPrecomputed.java
+++ b/src/main/org/deidentifier/arx/metric/v2/MetricMDNUEntropyPrecomputed.java
@@ -19,10 +19,12 @@ package org.deidentifier.arx.metric.v2;
 
 import java.util.Arrays;
 
+import org.apache.commons.math3.fraction.BigFraction;
 import org.deidentifier.arx.ARXConfiguration;
 import org.deidentifier.arx.DataDefinition;
 import org.deidentifier.arx.RowSet;
 import org.deidentifier.arx.certificate.elements.ElementData;
+import org.deidentifier.arx.criteria.EDDifferentialPrivacy;
 import org.deidentifier.arx.framework.check.groupify.HashGroupify;
 import org.deidentifier.arx.framework.check.groupify.HashGroupifyEntry;
 import org.deidentifier.arx.framework.data.Data;
@@ -31,6 +33,8 @@ import org.deidentifier.arx.framework.data.DataMatrix;
 import org.deidentifier.arx.framework.data.GeneralizationHierarchy;
 import org.deidentifier.arx.framework.lattice.Transformation;
 import org.deidentifier.arx.metric.MetricConfiguration;
+
+import com.carrotsearch.hppc.IntIntOpenHashMap;
 
 /**
  * This class provides an efficient implementation of the non-uniform entropy
@@ -78,6 +82,9 @@ public class MetricMDNUEntropyPrecomputed extends AbstractMetricMultiDimensional
 
     /** Num rows */
     private double        rows;
+
+    /** The root values of all generalization hierarchies or -1 if no single root value exists */
+    private int[]         rootValues;
 
     /**
      * Precomputed.
@@ -128,12 +135,67 @@ public class MetricMDNUEntropyPrecomputed extends AbstractMetricMultiDimensional
     }
     
     @Override
+    public ILScore getScore(final Transformation node, final HashGroupify groupify) {
+        
+        // Prepare
+        int dimensionsGeneralized = getDimensionsGeneralized();
+        IntIntOpenHashMap[] nonSuppressedValueToCount = new IntIntOpenHashMap[dimensionsGeneralized];
+        for (int dimension=0; dimension<dimensionsGeneralized; dimension++) {
+            nonSuppressedValueToCount[dimension] = new IntIntOpenHashMap();
+        }
+
+        // Compute score. The casts to long are required to avoid integer overflows
+        // when large numbers are being multiplied.
+        BigFraction score = BigFraction.ZERO;
+        HashGroupifyEntry m = groupify.getFirstEquivalenceClass();
+        while (m != null) {
+            m.read();
+            for (int dimension=0; dimension<dimensionsGeneralized; dimension++) {
+                int value = m.next();
+                // Process values of records which have not been suppressed by sampling
+                if (m.isNotOutlier && (rootValues[dimension] == -1 || value != rootValues[dimension])) {
+                    // The attribute value has neither been suppressed because of record suppression nor because of generalization
+                    nonSuppressedValueToCount[dimension].putOrAdd(value, m.count, m.count);
+                } else {
+                    // The attribute value has been suppressed because of record suppression or because of generalization
+                    score = score.add(new BigFraction((long)m.count * (long)rows));
+                }
+                // Add values for records which have been suppressed by sampling
+                score = score.add(new BigFraction((long)(m.pcount - m.count) * (long)rows));
+            }
+            m = m.nextOrdered;
+        }
+        // Add values for all attribute values which were not suppressed
+        for (int dimension=0; dimension<dimensionsGeneralized; dimension++) {
+            final boolean [] states = nonSuppressedValueToCount[dimension].allocated;
+            final int [] counts = nonSuppressedValueToCount[dimension].values;
+            for (int i=0; i<states.length; i++) {
+                if (states[i]) {
+                    score = score.add(new BigFraction((long)counts[i] * (long)counts[i]));
+                }
+            }
+        }
+
+        // Adjust sensitivity and multiply with -1 so that higher values are better
+        score = score.multiply(BigFraction.MINUS_ONE.divide(new BigFraction(((long)rows * (long)dimensionsGeneralized))));
+        score = score.divide((k == 1) ? new BigFraction(5) : new BigFraction(k * k).divide(new BigFraction(k - 1)).add(BigFraction.ONE));
+        
+        // Return score
+        return new ILScore(score);
+    }
+    
+    @Override
     public boolean isGSFactorSupported() {
         return true;
     }
 
     @Override
     public boolean isPrecomputed() {
+        return true;
+    }
+    
+    @Override
+    public boolean isScoreFunctionSupported() {
         return true;
     }
 
@@ -328,6 +390,23 @@ public class MetricMDNUEntropyPrecomputed extends AbstractMetricMultiDimensional
         double[] max = new double[hierarchies.length];
         for (int i=0; i<max.length; i++) {
             max[i] = (input.getDataLength() * log2(input.getDataLength())) * Math.max(gFactor, sFactor);
+        }
+        
+        if (config.isPrivacyModelSpecified(EDDifferentialPrivacy.class)) {
+            // Store root values of generalization hierarchies or null if no single root value exists
+            rootValues = new int[hierarchies.length];
+            for (int i = 0; i < hierarchies.length; i++) {
+                int rootValue = -1;
+                for (int[] row : hierarchies[i].getArray()) {
+                    if (rootValue == -1) {
+                        rootValue = row[row.length-1];
+                    } else if (row[row.length-1] != rootValue) {
+                        rootValue = -1;
+                        break;
+                    }
+                }
+                rootValues[i] = rootValue;
+            }
         }
         
         super.setMax(max);

--- a/src/main/org/deidentifier/arx/metric/v2/MetricSDAECS.java
+++ b/src/main/org/deidentifier/arx/metric/v2/MetricSDAECS.java
@@ -17,6 +17,7 @@
 
 package org.deidentifier.arx.metric.v2;
 
+import org.apache.commons.math3.fraction.BigFraction;
 import org.deidentifier.arx.ARXConfiguration;
 import org.deidentifier.arx.certificate.elements.ElementData;
 import org.deidentifier.arx.framework.check.groupify.HashGroupify;
@@ -31,6 +32,7 @@ import org.deidentifier.arx.metric.MetricConfiguration;
  * 
  * @author Fabian Prasser
  * @author Florian Kohlmayer
+ * @author Raffael Bild
  */
 public class MetricSDAECS extends AbstractMetricSingleDimensional {
 
@@ -93,7 +95,39 @@ public class MetricSDAECS extends AbstractMetricSingleDimensional {
     }
     
     @Override
+    public ILScore getScore(final Transformation node, final HashGroupify groupify) {
+        
+        // Calculate the number of all equivalence classes, regarding all suppressed records to belong to one class
+        
+        boolean hasSuppressed = false;
+        int numberOfNonSuppressedClasses = 0;
+        
+        HashGroupifyEntry entry = groupify.getFirstEquivalenceClass();
+        while (entry != null) {
+            if (!entry.isNotOutlier && entry.count > 0 || entry.pcount > entry.count) {
+                // The equivalence class is suppressed or contains records removed by sampling
+                hasSuppressed = true;
+            }
+            if (entry.isNotOutlier && entry.count > 0) {
+                // The equivalence class contains records which are not suppressed
+                numberOfNonSuppressedClasses++;
+            }
+            // Next group
+            entry = entry.nextOrdered;
+        }
+        
+        // Calculate the score. Dividing by the sensitivity is not required because this score function has a sensitivity of one.
+        BigFraction score = new BigFraction(numberOfNonSuppressedClasses + (hasSuppressed ? 1d : 0d));
+        return new ILScore(score);
+    }
+    
+    @Override
     public boolean isGSFactorSupported() {
+        return true;
+    }
+    
+    @Override
+    public boolean isScoreFunctionSupported() {
         return true;
     }
 

--- a/src/main/org/deidentifier/arx/metric/v2/MetricSDNMDiscernability.java
+++ b/src/main/org/deidentifier/arx/metric/v2/MetricSDNMDiscernability.java
@@ -17,10 +17,16 @@
 
 package org.deidentifier.arx.metric.v2;
 
+import org.apache.commons.math3.fraction.BigFraction;
 import org.deidentifier.arx.ARXConfiguration;
+import org.deidentifier.arx.DataDefinition;
 import org.deidentifier.arx.certificate.elements.ElementData;
+import org.deidentifier.arx.criteria.EDDifferentialPrivacy;
 import org.deidentifier.arx.framework.check.groupify.HashGroupify;
 import org.deidentifier.arx.framework.check.groupify.HashGroupifyEntry;
+import org.deidentifier.arx.framework.data.Data;
+import org.deidentifier.arx.framework.data.DataManager;
+import org.deidentifier.arx.framework.data.GeneralizationHierarchy;
 import org.deidentifier.arx.framework.lattice.Transformation;
 import org.deidentifier.arx.metric.MetricConfiguration;
 
@@ -30,11 +36,18 @@ import org.deidentifier.arx.metric.MetricConfiguration;
  * 
  * @author Fabian Prasser
  * @author Florian Kohlmayer
+ * @author Raffael Bild
  */
 public class MetricSDNMDiscernability extends AbstractMetricSingleDimensional {
     
     /** SVUID. */
     private static final long serialVersionUID = -8573084860566655278L;
+    
+    /** Total number of rows. */
+    private long              numRows;
+    
+    /** Minimal size of equivalence classes enforced by the differential privacy model */
+    private long              k;
 
     /**
      * Creates a new instance.
@@ -85,6 +98,40 @@ public class MetricSDNMDiscernability extends AbstractMetricSingleDimensional {
                                        0.0d,                       // precomputation threshold
                                        AggregateFunction.SUM       // aggregate function
                                        );
+    }
+    
+    @Override
+    public ILScore getScore(final Transformation node, final HashGroupify groupify) {
+        
+        // Prepare
+        int numSuppressed = 0;
+        BigFraction penaltyNotSuppressed = BigFraction.ZERO;
+        
+        // Sum up penalties. The casts to long are required to avoid integer overflows
+        // when large numbers are being multiplied.
+        HashGroupifyEntry m = groupify.getFirstEquivalenceClass();
+        while (m != null) {
+            if (m.isNotOutlier) {
+                penaltyNotSuppressed = penaltyNotSuppressed.add(new BigFraction((long)m.count * (long)m.count));
+            } else {
+                numSuppressed += m.count;
+            }
+            numSuppressed += m.pcount - m.count;
+            m = m.nextOrdered;
+        }
+        BigFraction penaltySuppressed = new BigFraction(numRows * (long)numSuppressed);
+        
+        // Adjust sensitivity and multiply with -1 so that higher values are better
+        BigFraction score = BigFraction.MINUS_ONE.multiply(penaltySuppressed.add(penaltyNotSuppressed));
+        score = score.divide(new BigFraction(numRows).multiply((k == 1) ? new BigFraction(5) : new BigFraction(k * k).divide(new BigFraction(k - 1)).add(BigFraction.ONE)));
+        
+        // Return score
+        return new ILScore(score);
+    }
+    
+    @Override
+    public boolean isScoreFunctionSupported() {
+        return true;
     }
 
     @Override
@@ -138,6 +185,23 @@ public class MetricSDNMDiscernability extends AbstractMetricSingleDimensional {
             m = m.nextOrdered;
         }
         return new ILSingleDimensional(lowerBound);
+    }
+    
+    @Override
+    protected void initializeInternal(final DataManager manager,
+                                      final DataDefinition definition, 
+                                      final Data input, 
+                                      final GeneralizationHierarchy[] hierarchies, 
+                                      final ARXConfiguration config) {
+        
+        super.initializeInternal(manager, definition, input, hierarchies, config);
+
+        // Store minimal size of equivalence classes and total number of rows
+        if (config.isPrivacyModelSpecified(EDDifferentialPrivacy.class)) {
+            EDDifferentialPrivacy dpCriterion = config.getPrivacyModel(EDDifferentialPrivacy.class);
+            numRows = input.getDataLength();
+            k = dpCriterion.getMinimalClassSize();
+        }
     }
 }
 

--- a/src/test/org/deidentifier/arx/test/TestAnonymizationDifferentialPrivacy.java
+++ b/src/test/org/deidentifier/arx/test/TestAnonymizationDifferentialPrivacy.java
@@ -51,7 +51,8 @@ public class TestAnonymizationDifferentialPrivacy extends AbstractAnonymizationT
     @Parameters(name = "{index}:[{0}]")
     public static Collection<Object[]> cases() {
         return Arrays.asList(new Object[][] {
-                                              /* 0 */{ new ARXAnonymizationTestCase(ARXConfiguration.create(1d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(2d, 1E-5d, DataGeneralizationScheme.create(GeneralizationDegree.LOW_MEDIUM), true)), "./data/adult.csv", 0.6820705793543056, new int[] { 0, 2, 0, 1, 1, 1, 1, 1, 0 }, false) },
+                                              /* Data-independent differential privacy */
+                                              /* 0 */ { new ARXAnonymizationTestCase(ARXConfiguration.create(1d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(2d, 1E-5d, DataGeneralizationScheme.create(GeneralizationDegree.LOW_MEDIUM), true)), "./data/adult.csv", 0.6820705793543056, new int[] { 0, 2, 0, 1, 1, 1, 1, 1, 0 }, false) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(1d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(1.5d, 1E-6d, DataGeneralizationScheme.create(GeneralizationDegree.HIGH), true)), "./data/adult.csv", 0.8112222411559193, new int[] { 1, 3, 1, 2, 2, 2, 2, 2, 1 }, false) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(0.0d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(LN2, 1E-7d, DataGeneralizationScheme.create(GeneralizationDegree.LOW_MEDIUM), true)), "./data/adult.csv", 0.7437618217405468, new int[] { 0, 2, 0, 1, 1, 1, 1, 1, 0 }, false) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(0.0d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(LN3, 1E-8d, DataGeneralizationScheme.create(GeneralizationDegree.MEDIUM), true)), "./data/adult.csv", 0.6092780386290699, new int[] { 1, 2, 1, 1, 2, 1, 1, 1, 1 }, false) },
@@ -61,7 +62,7 @@ public class TestAnonymizationDifferentialPrivacy extends AbstractAnonymizationT
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(0.04d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(1.0d, 1E-8d, DataGeneralizationScheme.create(GeneralizationDegree.MEDIUM), true)), "./data/cup.csv", 0.8499906952842589, new int[] { 3, 2, 1, 1, 1, 2, 2, 2 }, false) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(1d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(2d, 1E-5d, DataGeneralizationScheme.create(GeneralizationDegree.LOW_MEDIUM), true)), "./data/cup.csv", 1.0000000000000004, new int[] { 2, 2, 0, 1, 0, 2, 2, 2 }, false) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(0.0d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(1.5d, 1E-6d, DataGeneralizationScheme.create(GeneralizationDegree.MEDIUM_HIGH), true)), "./data/cup.csv", 0.7606582708058056, new int[] { 3, 2, 1, 1, 1, 2, 2, 2 }, false) },
-                                              /* 10 */{ new ARXAnonymizationTestCase(ARXConfiguration.create(0.04d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(2d, 1E-7d, DataGeneralizationScheme.create(GeneralizationDegree.LOW_MEDIUM), true)), "./data/cup.csv", 1.0000000000000004, new int[] { 2, 2, 0, 1, 0, 2, 2, 2 }, true) },
+                                              /* 10 */ { new ARXAnonymizationTestCase(ARXConfiguration.create(0.04d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(2d, 1E-7d, DataGeneralizationScheme.create(GeneralizationDegree.LOW_MEDIUM), true)), "./data/cup.csv", 1.0000000000000004, new int[] { 2, 2, 0, 1, 0, 2, 2, 2 }, true) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(1d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(LN3, 1E-8d, DataGeneralizationScheme.create(GeneralizationDegree.MEDIUM), true)), "./data/cup.csv", 0.839519540778112, new int[] { 3, 2, 1, 1, 1, 2, 2, 2 }, true) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(0.04d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(2d, 1E-5d, DataGeneralizationScheme.create(GeneralizationDegree.LOW_MEDIUM), true)), "./data/fars.csv", 0.5814200080206713, new int[] { 2, 1, 1, 1, 0, 1, 1, 1 }, false) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(1d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(LN2, 1E-6d, DataGeneralizationScheme.create(GeneralizationDegree.HIGH), true)), "./data/fars.csv", 0.6800577425519756, new int[] { 4, 2, 2, 2, 1, 2, 2, 2 }, false) },
@@ -69,7 +70,56 @@ public class TestAnonymizationDifferentialPrivacy extends AbstractAnonymizationT
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(0.0d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(1.5d, 1E-8d, DataGeneralizationScheme.create(GeneralizationDegree.MEDIUM), true)), "./data/fars.csv", 0.43090885593016726, new int[] { 3, 1, 2, 2, 1, 1, 2, 1 }, false) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(1d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(LN3, 1E-5d, DataGeneralizationScheme.create(GeneralizationDegree.HIGH), true)), "./data/fars.csv", 0.6796862034370221, new int[] { 4, 2, 2, 2, 1, 2, 2, 2 }, true) },
                                               { new ARXAnonymizationTestCase(ARXConfiguration.create(0.04d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(1.0d, 1E-6d, DataGeneralizationScheme.create(GeneralizationDegree.MEDIUM_HIGH), true)), "./data/fars.csv", 0.40463191801066123, new int[] { 3, 1, 2, 2, 1, 1, 2, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(ARXConfiguration.create(1d, Metric.createLossMetric()).addPrivacyModel(new EDDifferentialPrivacy(0.01d, 1E-9d, DataGeneralizationScheme.create(GeneralizationDegree.LOW_MEDIUM), true)), "./data/adult.csv", 0.9999999999999989, new int[] { 0, 2, 0, 1, 1, 1, 1, 1, 0 }, false) },
+                                              /* Data-dependent differential privacy */
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createLossMetric(), 2d, 1d, 1E-5d, 10), "", "./data/adult.csv", "-1095104 / 2745", new int[] { 0, 3, 0, 1, 3, 2, 2, 0, 1 }, false) },
+                                              /* 20 */ { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createLossMetric(), 2d, 1d, 1E-5d, 10), "", "./data/cup.csv", "-186959735276631 / 298440428440", new int[] { 4, 4, 0, 1, 0, 1, 3, 2 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createLossMetric(), 2d, 1d, 1E-5d, 10), "", "./data/fars.csv", "-1393998867 / 1298080", new int[] { 4, 1, 2, 3, 0, 1, 2, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createLossMetric(), 2d, 1d, 1E-5d, 100), "", "./data/adult.csv", "-1118952113 / 3151260", new int[] { 1, 3, 0, 1, 2, 1, 1, 1, 0 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createLossMetric(), 2d, 1d, 1E-5d, 100), "", "./data/cup.csv", "-9120140763047 / 13565474020", new int[] { 4, 3, 0, 1, 0, 3, 3, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createLossMetric(), 2d, 1d, 1E-5d, 100), "", "./data/fars.csv", "-596021863 / 563640", new int[] { 3, 1, 2, 1, 0, 1, 3, 0 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createPrecisionMetric(), 2d, 1d, 1E-5d, 10), "", "./data/adult.csv", "-202138 / 549", new int[] { 1, 4, 0, 1, 3, 0, 1, 2, 0 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createPrecisionMetric(), 2d, 1d, 1E-5d, 10), "", "./data/cup.csv", "-3652297 / 4880", new int[] { 4, 4, 0, 1, 0, 1, 3, 4 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createPrecisionMetric(), 2d, 1d, 1E-5d, 10), "", "./data/fars.csv", "-1386241 / 1220", new int[] { 4, 0, 2, 1, 0, 2, 3, 0 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createPrecisionMetric(), 2d, 1d, 1E-5d, 100), "", "./data/adult.csv", "-66137 / 183", new int[] { 0, 4, 0, 1, 2, 2, 2, 1, 0 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createPrecisionMetric(), 2d, 1d, 1E-5d, 100), "", "./data/cup.csv", "-912547 / 1220", new int[] { 4, 4, 0, 1, 0, 2, 4, 2 }, false) },
+                                              /* 30 */ { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createPrecisionMetric(), 2d, 1d, 1E-5d, 100), "", "./data/fars.csv", "-1393313 / 1220", new int[] { 3, 2, 2, 2, 0, 0, 2, 0 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createEntropyMetric(), 2d, 1d, 1E-5d, 10), "", "./data/adult.csv", "-192762840221 / 530021745", new int[] { 0, 3, 1, 1, 3, 2, 1, 1, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createEntropyMetric(), 2d, 1d, 1E-5d, 10), "", "./data/cup.csv", "-10594877476 / 16515807", new int[] { 4, 3, 0, 1, 0, 3, 3, 3 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createEntropyMetric(), 2d, 1d, 1E-5d, 10), "", "./data/fars.csv", "-138113554979 / 143330540", new int[] { 3, 1, 2, 2, 0, 1, 2, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createEntropyMetric(), 2d, 1d, 1E-5d, 100), "", "./data/adult.csv", "-177337737098 / 530021745", new int[] { 0, 3, 1, 1, 2, 1, 2, 1, 0 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createEntropyMetric(), 2d, 1d, 1E-5d, 100), "", "./data/cup.csv", "-10594877476 / 16515807", new int[] { 4, 3, 0, 1, 0, 3, 3, 3 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createEntropyMetric(), 2d, 1d, 1E-5d, 100), "", "./data/fars.csv", "-1523650501331 / 1576635940", new int[] { 4, 1, 2, 2, 0, 0, 1, 0 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createAECSMetric(), 2d, 1d, 1E-5d, 10), "", "./data/adult.csv", "48", new int[] { 0, 4, 0, 1, 3, 2, 2, 0, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createAECSMetric(), 2d, 1d, 1E-5d, 10), "", "./data/cup.csv", "203", new int[] { 5, 1, 1, 2, 0, 4, 4, 4 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createAECSMetric(), 2d, 1d, 1E-5d, 10), "", "./data/fars.csv", "65", new int[] { 4, 2, 3, 3, 0, 0, 2, 2 }, false) },
+                                              /* 40 */ { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createAECSMetric(), 2d, 1d, 1E-5d, 100), "", "./data/adult.csv", "83", new int[] { 0, 2, 1, 2, 1, 2, 2, 1, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createAECSMetric(), 2d, 1d, 1E-5d, 100), "", "./data/cup.csv", "227", new int[] { 5, 4, 1, 1, 1, 0, 4, 3 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createAECSMetric(), 2d, 1d, 1E-5d, 100), "", "./data/fars.csv", "313", new int[] { 2, 2, 3, 3, 1, 2, 0, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createDiscernabilityMetric(), 2d, 1d, 1E-5d, 10), "", "./data/adult.csv", "-4328373035 / 23556522", new int[] { 1, 4, 1, 1, 3, 2, 2, 0, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createDiscernabilityMetric(), 2d, 1d, 1E-5d, 10), "", "./data/cup.csv", "-92539517531 / 247737105", new int[] { 3, 4, 1, 2, 1, 4, 4, 4 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createDiscernabilityMetric(), 2d, 1d, 1E-5d, 10), "", "./data/fars.csv", "-238524858563 / 394158985", new int[] { 4, 2, 2, 3, 0, 2, 2, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createDiscernabilityMetric(), 2d, 1d, 1E-5d, 100), "", "./data/adult.csv", "-7269135699 / 39260870", new int[] { 0, 1, 1, 1, 3, 2, 2, 2, 1 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createDiscernabilityMetric(), 2d, 1d, 1E-5d, 100), "", "./data/cup.csv", "-30829181071 / 82579035", new int[] { 4, 3, 1, 1, 1, 4, 4, 4 }, false) },
+                                              { new ARXAnonymizationTestCase(createDataDependentConfiguration(Metric.createDiscernabilityMetric(), 2d, 1d, 1E-5d, 100), "", "./data/fars.csv", "-235473243893 / 394158985", new int[] { 5, 2, 1, 2, 1, 2, 1, 0 }, false) },
         });
+    }
+    
+    /**
+     * Creates a new test case for data-dependent differential privacy.
+     * @param metric
+     * @param epsilon
+     * @param searchBudget
+     * @param delta
+     * @param steps
+     * @return
+     */
+    private static ARXConfiguration createDataDependentConfiguration(Metric<?> metric, double epsilon, double searchBudget, double delta, int steps) {
+        ARXConfiguration result = ARXConfiguration.create(1d, metric);
+        result.addPrivacyModel(new EDDifferentialPrivacy(epsilon, delta, null, true));
+        result.setDPSearchBudget(searchBudget);
+        result.setDPSearchStepNumber(steps);
+        return result;
     }
     
     /**


### PR DESCRIPTION
* Change label

* Adjust example 37

* Revert "Adjust example 37"

This reverts commit 1c99274975e6f541d1571f17ad590b9cca509957.

* Adjust example

* Update commons-math3 library

* Revert example

* Prepare integration of data-dependent differential privacy

* Integrate data-dependent differential privacy into the API

* Bugfix

* Refactor ScoreType

* Various improvements

* Improve formatting and comments

* Integrate score functions

* Improve memory consumption caused by internal caches of the exponential
mechanism

* Small code improvement

* Small improvements